### PR TITLE
fixed compatiblity issue with CheckboxList and other controls

### DIFF
--- a/src/TwiGrid/DataGrid.latte
+++ b/src/TwiGrid/DataGrid.latte
@@ -180,7 +180,13 @@
 
 	<th n:class='filter-cell, ($hasControl = isset($form["filters-criteria-$column"])) && !($isControl = ($form["filters-criteria-$column"] instanceof Nette\Forms\IControl)) ? alert-warning'>
 	{if $hasControl && $isControl}
-		{? }{input filters-criteria-$column, class => 'form-control'}
+		{if $form['filters-criteria-'.$column]->getControl() instanceof Nette\Utils\Html}
+			{input filters-criteria-$column, class => 'form-control'}
+		{else}
+			{*compatibility issue of Nette\Forms\Controls\CheckboxList
+				::getControl() and others returning string instead of Html *}
+			{input filters-criteria-$column}
+		{/if}
 	{else}
 		&nbsp;
 	{/if}
@@ -276,7 +282,15 @@
 
 {define body-cell-inline}
 {ifset $form["inline-values-$column"]}
-	<td n:class='body-inline-cell, "body-inline-cell-{$column}"'>{input inline-values-$column, class => 'form-control'}</td>
+	<td n:class='body-inline-cell, "body-inline-cell-{$column}"'>
+		{if $form['inline-values-'.$column]->getControl() instanceof Nette\Utils\Html}
+			{input inline-values-$column, class => 'form-control'}
+		{else}
+			{*compatibility issue of Nette\Forms\Controls\CheckboxList
+			  ::getControl() and others returning string instead of Html *}
+			{input inline-values-$column}
+		{/if}
+	</td>
 {else}{ifset #body-cell-$column}
 {include #"body-cell-$column", (expand) get_defined_vars()}
 {else}


### PR DESCRIPTION
some controls are not returning Html object with ::getControl() method. Using them in inline form or filter caused the twigrid to crash without this fix.