### PR TITLE
Standardized placeholders for translate 

### DIFF
--- a/src/TwiGrid/DataGrid.latte
+++ b/src/TwiGrid/DataGrid.latte
@@ -436,7 +436,7 @@
 
 {define footer-info}
 	<div n:class="!$hasGroupActions && $grid->pageCount <= 1 ? col-xs-12 : col-xs-4, right" n:if="$isPaginated">
-		{($grid->page - 1) * $grid->itemsPerPage + 1}-{min($grid->itemCount, ($grid->page - 1) * $grid->itemsPerPage + $grid->itemsPerPage)} / {_'%d items', $grid->itemCount}
+		{($grid->page - 1) * $grid->itemsPerPage + 1}-{min($grid->itemCount, ($grid->page - 1) * $grid->itemsPerPage + $grid->itemsPerPage)} / {_'%count% items', $grid->itemCount}
 	</div>
 {/define}
 

--- a/src/TwiGrid/DataGrid.php
+++ b/src/TwiGrid/DataGrid.php
@@ -265,7 +265,7 @@ class DataGrid extends Nette\Application\UI\Control
 	 */
 	function translate($s, $count = NULL)
 	{
-		return $this->translator === NULL ? sprintf((string) $s, $count)
+		return $this->translator === NULL ? str_replace('%count%', $count, (string) $s)
 			: $this->translator->translate((string) $s, $count);
 	}
 


### PR DESCRIPTION
Use %count% as default count placeholder - same as Kdyby/Translate
