### PR TITLE
Bootstrap offset for scolling to first flash message

### DIFF
--- a/assets/twigrid.datagrid.js
+++ b/assets/twigrid.datagrid.js
@@ -223,7 +223,7 @@ $.nette.ext({
 				'data-dismiss': 'alert'
 			}));
 
-			var flashTop = flash.offset().top;
+			var flashTop = flash.offset().top - $('body').offset().top;
 
 			if (minFlashTop === null || flashTop > minFlashTop) {
 				minFlashTop = flashTop;


### PR DESCRIPTION
Bootstrap navbar creates an offset for body, which was not considered in scrolling mechanism to first flash message of grid after snippets is redrawed ==> fixed: bootstrap navbar is considered when calculating the offset to scroll