### PR TITLE
combined solution: update of scrolling to most top flash message

### DIFF
--- a/assets/twigrid.datagrid.js
+++ b/assets/twigrid.datagrid.js
@@ -213,7 +213,7 @@ $.nette.ext({
 
 		// scroll to most top flash message
 		var minFlashTop = null;
-		var bodyPaddingTop = parseInt($('body').css('padding-top'));
+		var bodyPaddingTopOffset = $('body').offset().top + parseInt($('body').css('padding-top'));
 
 		$(this.flashSelector, this.gridSelector).each(function () {
 			var flash = $(this);
@@ -224,7 +224,7 @@ $.nette.ext({
 				'data-dismiss': 'alert'
 			}));
 
-			var flashTop = flash.offset().top - bodyPaddingTop;
+			var flashTop = flash.offset().top - bodyPaddingTopOffset;
 
 			if (minFlashTop === null || flashTop > minFlashTop) {
 				minFlashTop = flashTop;


### PR DESCRIPTION
combined solution of #23 and https://github.com/uestla/TwiGrid/commit/bdb6ea4ea591c74e6fd67845cf488f69b595f05e :

`$('body').offset().top` solve a html element margin and padding as well as body element margin, while `parseInt($('body').css('padding-top'))` adds the body padding to the previous offset.

Now, I hope, that all cases are solved and all devs will not be surprised of malfunction and will be happy :-)