### PR TITLE
First datagrid ".header-cell" can select all rows only

### DIFF
--- a/assets/twigrid.datagrid.js
+++ b/assets/twigrid.datagrid.js
@@ -314,13 +314,14 @@ $.nette.ext({
 			});
 
 		$('.header-cell', header)
+			.first()
 			.off('click.tw-allrowcheck')
 			.on('click.tw-allrowcheck', function (event) {
 				if (!self.isClickable(event.target) && self.noMetaKeysPressed(event)) {
 					groupCheckbox.twgToggleChecked();
 				}
 			})
-			.first().html(groupCheckbox);
+			.html(groupCheckbox);
 
 		checkboxes.each(function (k, val) {
 			var checkbox = $(val);


### PR DESCRIPTION
Currently, all of ".header-cell"-s select all rows, which is not so practical and not intuitive/user-friendly if user click accidentally outside sort link or sort control button (but I hope, that it is only a bug of bad selector (".headel-cell" instead of ".header-cell:first-of-type" or wrongly placed of first() function ).

Second one was selected as a fix, because usage of .first() is needed in the firstly mentioned possible fix also.