### PR TITLE
Better class addition which preserve previously assigned classes

### DIFF
--- a/src/TwiGrid/DataGrid.latte
+++ b/src/TwiGrid/DataGrid.latte
@@ -275,7 +275,8 @@
 				? alert-warning
 	'>
 		{if $hasControl && $isControl}
-			{input filters-criteria-$columnName, class => 'form-control'}
+			{php $form["filters-criteria-$columnName"]->getControlPrototype()->addAttributes(['class' => 'form-control'])}
+			{input filters-criteria-$columnName}
 		{else}
 			&nbsp;
 		{/if}
@@ -421,7 +422,8 @@
 
 	{ifset $form["inline-values-$columnName"]}
 		<td n:class='body-inline-cell, "body-inline-cell-{$columnName}"'>
-			{input inline-values-$columnName, class => 'form-control'}
+			{php $form["inline-values-$columnName"]->getControlPrototype()->addAttributes(['class' => 'form-control'])}
+			{input inline-values-$columnName}
 		</td>
 
 	{elseifset #body-cell-$columnName}


### PR DESCRIPTION
If I use some classes on inputs, usage of:
`{input some-input, class => 'some-class'}`
leads to overwrite previously set classes.

However:
`$form['some-input']->getControlPrototype()->addAttributes(['class' => 'some-class'])`
leads to merge previously set classes with the other one classes.