### PR TITLE
Enabling of HTML label in header of cell

### DIFF
--- a/src/TwiGrid/Components/Column.php
+++ b/src/TwiGrid/Components/Column.php
@@ -10,11 +10,13 @@
 
 namespace TwiGrid\Components;
 
+use Nette\Utils\Html;
+
 
 class Column extends Component
 {
 
-	/** @var string */
+	/** @var string|Html */
 	private $label;
 
 	/** @var bool */
@@ -34,7 +36,8 @@ class Column extends Component
 	const DESC = TRUE;
 
 
-	public function __construct(string $label)
+	/** @param  string|Html $label */
+	public function __construct($label)
 	{
 		parent::__construct();
 
@@ -42,9 +45,14 @@ class Column extends Component
 	}
 
 
-	public function getLabel(): string
+	public function getLabel(): Html
 	{
-		return $this->translate($this->label);
+		if ($this->label instanceof Html) {
+			return $this->label;
+		}
+		else {
+			return Html::el()->addText($this->translate($this->label));
+		}
 	}
 
 


### PR DESCRIPTION
This is useful, if you would like to have icons in headers instead of text (for example font-avesome icon instead of long text) like this:
![image](https://cloud.githubusercontent.com/assets/10884140/24374989/0b617ffe-1337-11e7-8383-675f44ea9844.png)

@uestla: Please, check it - my original solution is for PHP 5.6 and I tried to rewrite and refactor to PHP 7.x, but only "blindfolded"..