### PR TITLE
Reverse conversion to DateTime object when Datetime as filter param

### DIFF
--- a/src/TwiGrid/DataGrid.php
+++ b/src/TwiGrid/DataGrid.php
@@ -189,6 +189,12 @@ class DataGrid extends NControl
 				$this->polluted = TRUE;
 			}
 		}
+    
+		foreach ($this->filters AS $fKey => $fValue) {
+			if (isset($fValue['date']) && isset($fValue['timezone_type']) && isset($fValue['timezone'])) {
+				$this->filters[$fKey] = new \DateTime($fValue['date'], new \DateTimeZone($fValue['timezone']));
+			}
+		}
 
 		$i = 0;
 		foreach ($this->orderBy as $column => $dir) {


### PR DESCRIPTION
Reverse conversion to DateTime object from array of datetime values (as filter param)

(in case of approval PR, please include it to 11.2.X release also - it is based on 11.X release)