### PR TITLE
Group Actions Fix

### DIFF
--- a/src/TwiGrid/DataGrid.php
+++ b/src/TwiGrid/DataGrid.php
@@ -815,7 +815,7 @@ class DataGrid extends NControl
 				if ($checked !== NULL) {
 					$records = [];
 					foreach ($checked as $primaryString) {
-						$record = $this->getRecordHandler()->findIn((string) $primaryString, $this->getData());
+						$record = $this->getRecordHandler()->findIn($primaryString, $this->getData());
 
 						if ($record !== NULL) {
 							$records[] = $record;

--- a/src/TwiGrid/Form.php
+++ b/src/TwiGrid/Form.php
@@ -108,7 +108,7 @@ class Form extends NForm
 
 		$this->validate();
 		if ($this->isValid()) {
-			return array_keys(array_filter($this['actions']['records']->getValues(TRUE)));
+			return array_map('strval', array_keys(array_filter($this['actions']['records']->getValues(TRUE))));
 		}
 
 		return NULL;


### PR DESCRIPTION
All checkbox values should be parsed as string, but sometimes there is an integer in `$primaryString` variable, which cause problem in `findIn()` function, where `$primary` parameter must be `string`.

![image](https://user-images.githubusercontent.com/16386245/46262958-27ecad80-c509-11e8-858d-eb8aaa803265.png)
